### PR TITLE
use deconstructed type values

### DIFF
--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -15,7 +15,7 @@ export function dispatch(sourceEvent: Event) {
 
 	for (let node of sourceEvent.composedPath()) {
 		if (node instanceof Element) {
-			let kind = node.getAttribute(`${sourceEvent.type}:`);
+			let kind = node.getAttribute(`${type}:`);
 			if (!kind) continue;
 
 			if (node.hasAttribute(`${type}:prevent-default`))


### PR DESCRIPTION
Use deconstructed value in `dispatch.ts` rather than hitting the sourceEvent type again