### PR TITLE
use mod only for exports

### DIFF
--- a/dist/action_event.d.ts
+++ b/dist/action_event.d.ts
@@ -1,13 +1,13 @@
 import type { DispatchParams } from "./type_flyweight.js";
-export interface ActionParamsInterface {
+export interface ActionInterface {
     sourceEvent: Event;
     action: string;
 }
 export interface ActionEventInterface {
-    actionParams: ActionParamsInterface;
+    actionParams: ActionInterface;
 }
 export declare class ActionEvent extends Event implements ActionEventInterface {
-    actionParams: ActionParamsInterface;
-    constructor(actionParams: ActionParamsInterface, eventInit?: EventInit);
+    actionParams: ActionInterface;
+    constructor(actionParams: ActionInterface, eventInit?: EventInit);
 }
 export declare function dispatchActionEvent(dispatchParams: DispatchParams): void;

--- a/dist/action_event.js
+++ b/dist/action_event.js
@@ -17,7 +17,7 @@ function getActionParams(dispatchParams) {
     let { el, sourceEvent } = dispatchParams;
     let { type } = sourceEvent;
     let action = el.getAttribute(`${type}:`);
-    if ("#action" === action) {
+    if ("_action" === action) {
         action = el.getAttribute(`${type}:action`);
     }
     if (action)

--- a/dist/esmodule_event.d.ts
+++ b/dist/esmodule_event.d.ts
@@ -1,18 +1,18 @@
 import type { DispatchParams } from "./type_flyweight.js";
-interface EsModuleEventRequestedInterface {
+interface EsModuleRequestedInterface {
     status: "requested";
     url: string;
 }
-interface EsModuleEventResolvedInterface {
+interface EsModuleResolvedInterface {
     status: "resolved";
     url: string;
 }
-interface EsModuleEventErrorStateInterface {
+interface EsModuleErrorInterface {
     status: "rejected";
     url: string;
     error: any;
 }
-export type EsModuleRequestState = EsModuleEventRequestedInterface | EsModuleEventResolvedInterface | EsModuleEventErrorStateInterface;
+export type EsModuleRequestState = EsModuleRequestedInterface | EsModuleResolvedInterface | EsModuleErrorInterface;
 export interface EsModuleEventInterface {
     requestState: EsModuleRequestState;
 }

--- a/dist/html_event.d.ts
+++ b/dist/html_event.d.ts
@@ -1,28 +1,28 @@
 import type { DispatchParams } from "./type_flyweight.js";
-interface HtmlEventParamsInterface {
+interface HtmlRequestInterface {
     request: Request;
     action: string;
     abortController: AbortController;
 }
-interface HtmlEventQueuedInterface extends HtmlEventParamsInterface {
+interface HtmlRequestQueuedInterface extends HtmlRequestInterface {
     status: "queued";
     queueTarget: EventTarget;
 }
-interface HtmlEventRequestedInterface extends HtmlEventParamsInterface {
+interface HtmlRequestRequestedInterface extends HtmlRequestInterface {
     status: "requested";
 }
-interface HtmlEventResolvedInterface extends HtmlEventParamsInterface {
+interface HtmlRequestResolvedInterface extends HtmlRequestInterface {
     status: "resolved";
     response: Response;
     html: string;
 }
-interface HtmlEventRejectedInterface extends HtmlEventParamsInterface {
+interface HtmlRequestRejectedInterface extends HtmlRequestInterface {
     status: "rejected";
     error: any;
 }
-export type HtmlRequestState = HtmlEventQueuedInterface | HtmlEventRejectedInterface | HtmlEventRequestedInterface | HtmlEventResolvedInterface;
+export type HtmlRequestState = HtmlRequestQueuedInterface | HtmlRequestRejectedInterface | HtmlRequestRequestedInterface | HtmlRequestResolvedInterface;
 export interface HtmlEventInterface {
-    requestState: HtmlEventParamsInterface;
+    requestState: HtmlRequestState;
 }
 export declare class HtmlEvent extends Event implements HtmlEventInterface {
     requestState: HtmlRequestState;

--- a/dist/html_event.d.ts
+++ b/dist/html_event.d.ts
@@ -22,9 +22,9 @@ interface HtmlEventRejectedInterface extends HtmlEventParamsInterface {
 }
 export type HtmlRequestState = HtmlEventQueuedInterface | HtmlEventRejectedInterface | HtmlEventRequestedInterface | HtmlEventResolvedInterface;
 export interface HtmlEventInterface {
-    htmlParams: HtmlEventParamsInterface;
+    requestState: HtmlEventParamsInterface;
 }
-export declare class HtmlEvent extends Event {
+export declare class HtmlEvent extends Event implements HtmlEventInterface {
     requestState: HtmlRequestState;
     constructor(requestState: HtmlRequestState, eventInit?: EventInit);
 }

--- a/dist/hyper_events.d.ts
+++ b/dist/hyper_events.d.ts
@@ -1,0 +1,15 @@
+export interface HyperEventsParamsInterface {
+    target: EventTarget;
+    eventNames: string[];
+    connected?: boolean;
+}
+export interface HyperEventsInterface {
+    connect(): void;
+    disconnect(): void;
+}
+export declare class HyperEvents {
+    #private;
+    constructor(params: HyperEventsParamsInterface);
+    connect(): void;
+    disconnect(): void;
+}

--- a/dist/hyper_events.js
+++ b/dist/hyper_events.js
@@ -1,0 +1,21 @@
+import { dispatch } from "./dispatch.js";
+export class HyperEvents {
+    #params;
+    constructor(params) {
+        this.#params = params;
+        if (this.#params.connected)
+            this.connect();
+    }
+    connect() {
+        let { target, eventNames } = this.#params;
+        for (let name of eventNames) {
+            target.addEventListener(name, dispatch);
+        }
+    }
+    disconnect() {
+        let { target, eventNames } = this.#params;
+        for (let name of eventNames) {
+            target.removeEventListener(name, dispatch);
+        }
+    }
+}

--- a/dist/json_event.d.ts
+++ b/dist/json_event.d.ts
@@ -1,26 +1,26 @@
 import type { DispatchParams } from "./type_flyweight.js";
-interface JsonEventParamsInterface {
+interface JsonRequestInterface {
     request: Request;
     action: string;
     abortController: AbortController;
 }
-interface JsonEventQueuedInterface extends JsonEventParamsInterface {
+interface JsonRequestQueuedInterface extends JsonRequestInterface {
     status: "queued";
     queueTarget: EventTarget;
 }
-interface JsonEventRequestedInterface extends JsonEventParamsInterface {
+interface JsonRequestRequestedInterface extends JsonRequestInterface {
     status: "requested";
 }
-interface JsonEventResolvedInterface extends JsonEventParamsInterface {
+interface JsonRequestResolvedInterface extends JsonRequestInterface {
     status: "resolved";
     response: Response;
     json: any;
 }
-interface JsonEventRejectedInterface extends JsonEventParamsInterface {
+interface JsonRequestRejectedInterface extends JsonRequestInterface {
     status: "rejected";
     error: any;
 }
-export type JsonRequestState = JsonEventQueuedInterface | JsonEventRequestedInterface | JsonEventResolvedInterface | JsonEventRejectedInterface;
+export type JsonRequestState = JsonRequestQueuedInterface | JsonRequestRequestedInterface | JsonRequestResolvedInterface | JsonRequestRejectedInterface;
 export interface JsonEventInterface {
     requestState: JsonRequestState;
 }

--- a/dist/mod.d.ts
+++ b/dist/mod.d.ts
@@ -1,23 +1,10 @@
-export type { ActionEventInterface, ActionParamsInterface, } from "./action_event.ts";
+export type { ActionEventInterface, ActionInterface, } from "./action_event.ts";
 export type { EsModuleEventInterface, EsModuleRequestState, } from "./esmodule_event.ts";
 export type { JsonEventInterface, JsonRequestState } from "./json_event.ts";
 export type { HtmlEventInterface, HtmlRequestState } from "./html_event.ts";
+export type { HyperEventsParamsInterface, HyperEventsInterface, } from "./hyper_events.ts";
 export { ActionEvent } from "./action_event.js";
 export { EsModuleEvent } from "./esmodule_event.js";
 export { JsonEvent } from "./json_event.js";
 export { HtmlEvent } from "./html_event.js";
-export interface HyperEventsParamsInterface {
-    target: EventTarget;
-    eventNames: string[];
-    connected?: boolean;
-}
-export interface HyperEventsInterface {
-    connect(): void;
-    disconnect(): void;
-}
-export declare class HyperEvents {
-    #private;
-    constructor(params: HyperEventsParamsInterface);
-    connect(): void;
-    disconnect(): void;
-}
+export { HyperEvents } from "./hyper_events.js";

--- a/dist/mod.d.ts
+++ b/dist/mod.d.ts
@@ -1,4 +1,4 @@
-export type { ActionEventInterface, ActionInterface, } from "./action_event.ts";
+export type { ActionEventInterface, ActionInterface } from "./action_event.ts";
 export type { EsModuleEventInterface, EsModuleRequestState, } from "./esmodule_event.ts";
 export type { JsonEventInterface, JsonRequestState } from "./json_event.ts";
 export type { HtmlEventInterface, HtmlRequestState } from "./html_event.ts";

--- a/dist/mod.js
+++ b/dist/mod.js
@@ -1,25 +1,5 @@
-import { dispatch } from "./dispatch.js";
 export { ActionEvent } from "./action_event.js";
 export { EsModuleEvent } from "./esmodule_event.js";
 export { JsonEvent } from "./json_event.js";
 export { HtmlEvent } from "./html_event.js";
-export class HyperEvents {
-    #params;
-    constructor(params) {
-        this.#params = params;
-        if (this.#params.connected)
-            this.connect();
-    }
-    connect() {
-        let { target, eventNames } = this.#params;
-        for (let name of eventNames) {
-            target.addEventListener(name, dispatch);
-        }
-    }
-    disconnect() {
-        let { target, eventNames } = this.#params;
-        for (let name of eventNames) {
-            target.removeEventListener(name, dispatch);
-        }
-    }
-}
+export { HyperEvents } from "./hyper_events.js";

--- a/examples/hypertext/mod.ts
+++ b/examples/hypertext/mod.ts
@@ -1,18 +1,18 @@
 import type {
-	ActionEvent,
-	HtmlEvent,
-	JsonEvent,
-	EsModuleEvent,
+	ActionEventInterface,
+	EsModuleEventInterface,
+	JsonEventInterface,
+	HtmlEventInterface,
 } from "hyperevents";
 
 import { HyperEvents } from "hyperevents";
 
 declare global {
 	interface GlobalEventHandlersEventMap {
-		["#action"]: ActionEvent;
-		["#esmodule"]: EsModuleEvent;
-		["#json"]: JsonEvent;
-		["#html"]: HtmlEvent;
+		["#action"]: ActionEventInterface;
+		["#esmodule"]: EsModuleEventInterface;
+		["#json"]: JsonEventInterface;
+		["#html"]: HtmlEventInterface;
 	}
 }
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -6,7 +6,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"hyperevents": "../../dist/mod.js"
+					"hyperevents": "../../dist/mod.js",
+					"hyperevents/": "../../dist/"
 				}
 			}
 		</script>

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -3,7 +3,8 @@
 	"compilerOptions": {
 		"declaration": false,
 		"paths": {
-			"hyperevents": ["../dist/mod.d.ts"]
+			"hyperevents": ["../dist/mod.d.ts"],
+			"hyperevents/*": ["../dist/*"]
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
 	"name": "hyperevents",
 	"version": "0.1.0",
 	"description": "declarative HTML projections",
+	"type": "module",
+	"main": "dist/mod.js",
 	"scripts": {
 		"build": "npx tsc --project ./src",
 		"build:examples": "npx tsc --project ./examples",

--- a/src/action_event.ts
+++ b/src/action_event.ts
@@ -1,18 +1,18 @@
 import type { DispatchParams } from "./type_flyweight.js";
 
-export interface ActionParamsInterface {
+export interface ActionInterface {
 	sourceEvent: Event;
 	action: string;
 }
 
 export interface ActionEventInterface {
-	actionParams: ActionParamsInterface;
+	actionParams: ActionInterface;
 }
 
 export class ActionEvent extends Event implements ActionEventInterface {
-	actionParams: ActionParamsInterface;
+	actionParams: ActionInterface;
 
-	constructor(actionParams: ActionParamsInterface, eventInit?: EventInit) {
+	constructor(actionParams: ActionInterface, eventInit?: EventInit) {
 		super("#action", eventInit);
 		this.actionParams = actionParams;
 	}
@@ -30,12 +30,12 @@ export function dispatchActionEvent(dispatchParams: DispatchParams) {
 
 function getActionParams(
 	dispatchParams: DispatchParams,
-): ActionParamsInterface | undefined {
+): ActionInterface | undefined {
 	let { el, sourceEvent } = dispatchParams;
 	let { type } = sourceEvent;
 
 	let action = el.getAttribute(`${type}:`);
-	if ("#action" === action) {
+	if ("_action" === action) {
 		action = el.getAttribute(`${type}:action`);
 	}
 

--- a/src/esmodule_event.ts
+++ b/src/esmodule_event.ts
@@ -1,25 +1,25 @@
 import type { DispatchParams } from "./type_flyweight.js";
 
-interface EsModuleEventRequestedInterface {
+interface EsModuleRequestedInterface {
 	status: "requested";
 	url: string;
 }
 
-interface EsModuleEventResolvedInterface {
+interface EsModuleResolvedInterface {
 	status: "resolved";
 	url: string;
 }
 
-interface EsModuleEventErrorStateInterface {
+interface EsModuleErrorInterface {
 	status: "rejected";
 	url: string;
 	error: any;
 }
 
 export type EsModuleRequestState =
-	| EsModuleEventRequestedInterface
-	| EsModuleEventResolvedInterface
-	| EsModuleEventErrorStateInterface;
+	| EsModuleRequestedInterface
+	| EsModuleResolvedInterface
+	| EsModuleErrorInterface;
 
 export interface EsModuleEventInterface {
 	requestState: EsModuleRequestState;

--- a/src/html_event.ts
+++ b/src/html_event.ts
@@ -37,10 +37,10 @@ export type HtmlRequestState =
 	| HtmlEventResolvedInterface;
 
 export interface HtmlEventInterface {
-	htmlParams: HtmlEventParamsInterface;
+	requestState: HtmlEventParamsInterface;
 }
 
-export class HtmlEvent extends Event {
+export class HtmlEvent extends Event implements HtmlEventInterface {
 	requestState: HtmlRequestState;
 
 	constructor(requestState: HtmlRequestState, eventInit?: EventInit) {

--- a/src/html_event.ts
+++ b/src/html_event.ts
@@ -4,40 +4,40 @@ import { getRequestParams, createRequest } from "./type_flyweight.js";
 import { setThrottler, getThrottleParams, shouldThrottle } from "./throttle.js";
 import { getQueueParams, enqueue, Queueable } from "./queue.js";
 
-interface HtmlEventParamsInterface {
+interface HtmlRequestInterface {
 	request: Request;
 	action: string;
 	abortController: AbortController;
 }
 
-interface HtmlEventQueuedInterface extends HtmlEventParamsInterface {
+interface HtmlRequestQueuedInterface extends HtmlRequestInterface {
 	status: "queued";
 	queueTarget: EventTarget;
 }
 
-interface HtmlEventRequestedInterface extends HtmlEventParamsInterface {
+interface HtmlRequestRequestedInterface extends HtmlRequestInterface {
 	status: "requested";
 }
 
-interface HtmlEventResolvedInterface extends HtmlEventParamsInterface {
+interface HtmlRequestResolvedInterface extends HtmlRequestInterface {
 	status: "resolved";
 	response: Response;
 	html: string;
 }
 
-interface HtmlEventRejectedInterface extends HtmlEventParamsInterface {
+interface HtmlRequestRejectedInterface extends HtmlRequestInterface {
 	status: "rejected";
 	error: any;
 }
 
 export type HtmlRequestState =
-	| HtmlEventQueuedInterface
-	| HtmlEventRejectedInterface
-	| HtmlEventRequestedInterface
-	| HtmlEventResolvedInterface;
+	| HtmlRequestQueuedInterface
+	| HtmlRequestRejectedInterface
+	| HtmlRequestRequestedInterface
+	| HtmlRequestResolvedInterface;
 
 export interface HtmlEventInterface {
-	requestState: HtmlEventParamsInterface;
+	requestState: HtmlRequestState;
 }
 
 export class HtmlEvent extends Event implements HtmlEventInterface {
@@ -64,7 +64,7 @@ export function dispatchHtmlEvent(dispatchParams: DispatchParams) {
 	if (!request) return;
 
 	let { action } = requestParams;
-	let fetchParams: HtmlEventParamsInterface = {
+	let fetchParams: HtmlRequestInterface = {
 		action,
 		request,
 		abortController,
@@ -86,7 +86,7 @@ export function dispatchHtmlEvent(dispatchParams: DispatchParams) {
 }
 
 function fetchHtml(
-	fetchParams: HtmlEventParamsInterface,
+	fetchParams: HtmlRequestInterface,
 	dispatchParams: DispatchParams,
 	abortController: AbortController,
 ): Promise<void> | undefined {

--- a/src/hyper_events.ts
+++ b/src/hyper_events.ts
@@ -1,0 +1,37 @@
+import { dispatch } from "./dispatch.js";
+
+export interface HyperEventsParamsInterface {
+	target: EventTarget;
+	eventNames: string[];
+	connected?: boolean;
+}
+
+export interface HyperEventsInterface {
+	connect(): void;
+	disconnect(): void;
+}
+
+export class HyperEvents {
+	#params: HyperEventsParamsInterface;
+
+	constructor(params: HyperEventsParamsInterface) {
+		this.#params = params;
+		if (this.#params.connected) this.connect();
+	}
+
+	connect() {
+		let { target, eventNames } = this.#params;
+
+		for (let name of eventNames) {
+			target.addEventListener(name, dispatch);
+		}
+	}
+
+	disconnect() {
+		let { target, eventNames } = this.#params;
+
+		for (let name of eventNames) {
+			target.removeEventListener(name, dispatch);
+		}
+	}
+}

--- a/src/json_event.ts
+++ b/src/json_event.ts
@@ -4,37 +4,37 @@ import { getRequestParams, createRequest } from "./type_flyweight.js";
 import { setThrottler, getThrottleParams, shouldThrottle } from "./throttle.js";
 import { getQueueParams, enqueue, Queueable } from "./queue.js";
 
-interface JsonEventParamsInterface {
+interface JsonRequestInterface {
 	request: Request;
 	action: string;
 	abortController: AbortController;
 }
 
-interface JsonEventQueuedInterface extends JsonEventParamsInterface {
+interface JsonRequestQueuedInterface extends JsonRequestInterface {
 	status: "queued";
 	queueTarget: EventTarget;
 }
 
-interface JsonEventRequestedInterface extends JsonEventParamsInterface {
+interface JsonRequestRequestedInterface extends JsonRequestInterface {
 	status: "requested";
 }
 
-interface JsonEventResolvedInterface extends JsonEventParamsInterface {
+interface JsonRequestResolvedInterface extends JsonRequestInterface {
 	status: "resolved";
 	response: Response;
 	json: any;
 }
 
-interface JsonEventRejectedInterface extends JsonEventParamsInterface {
+interface JsonRequestRejectedInterface extends JsonRequestInterface {
 	status: "rejected";
 	error: any;
 }
 
 export type JsonRequestState =
-	| JsonEventQueuedInterface
-	| JsonEventRequestedInterface
-	| JsonEventResolvedInterface
-	| JsonEventRejectedInterface;
+	| JsonRequestQueuedInterface
+	| JsonRequestRequestedInterface
+	| JsonRequestResolvedInterface
+	| JsonRequestRejectedInterface;
 
 export interface JsonEventInterface {
 	requestState: JsonRequestState;
@@ -64,7 +64,7 @@ export function dispatchJsonEvent(dispatchParams: DispatchParams) {
 	if (!request) return;
 
 	let { action } = requestParams;
-	let fetchParams: JsonEventParamsInterface = {
+	let fetchParams: JsonRequestInterface = {
 		action,
 		request,
 		abortController,
@@ -92,7 +92,7 @@ export function dispatchJsonEvent(dispatchParams: DispatchParams) {
 }
 
 function fetchJson(
-	fetchParams: JsonEventParamsInterface,
+	fetchParams: JsonRequestInterface,
 	dispatchParams: DispatchParams,
 	abortController: AbortController,
 ): Promise<void> | undefined {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,53 +1,17 @@
-import { dispatch } from "./dispatch.js";
-
-export type {
-	ActionEventInterface,
-	ActionParamsInterface,
-} from "./action_event.ts";
+export type { ActionEventInterface, ActionInterface } from "./action_event.ts";
 export type {
 	EsModuleEventInterface,
 	EsModuleRequestState,
 } from "./esmodule_event.ts";
 export type { JsonEventInterface, JsonRequestState } from "./json_event.ts";
 export type { HtmlEventInterface, HtmlRequestState } from "./html_event.ts";
+export type {
+	HyperEventsParamsInterface,
+	HyperEventsInterface,
+} from "./hyper_events.ts";
 
 export { ActionEvent } from "./action_event.js";
 export { EsModuleEvent } from "./esmodule_event.js";
 export { JsonEvent } from "./json_event.js";
 export { HtmlEvent } from "./html_event.js";
-
-export interface HyperEventsParamsInterface {
-	target: EventTarget;
-	eventNames: string[];
-	connected?: boolean;
-}
-
-export interface HyperEventsInterface {
-	connect(): void;
-	disconnect(): void;
-}
-
-export class HyperEvents {
-	#params: HyperEventsParamsInterface;
-
-	constructor(params: HyperEventsParamsInterface) {
-		this.#params = params;
-		if (this.#params.connected) this.connect();
-	}
-
-	connect() {
-		let { target, eventNames } = this.#params;
-
-		for (let name of eventNames) {
-			target.addEventListener(name, dispatch);
-		}
-	}
-
-	disconnect() {
-		let { target, eventNames } = this.#params;
-
-		for (let name of eventNames) {
-			target.removeEventListener(name, dispatch);
-		}
-	}
-}
+export { HyperEvents } from "./hyper_events.js";


### PR DESCRIPTION
Mod.js is now used as a centralized export for types and interfaces.

All events and event interfaces are exported from mod.js.

The HyperEvents controller and it's corresponding types are exported from mod.js. 